### PR TITLE
Fix export mapping pointing to invalid src folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@software-hardware-integration-lab/development-utilities",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@software-hardware-integration-lab/development-utilities",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "~10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@software-hardware-integration-lab/development-utilities",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Collection of configurations, settings and packages to be common across multiple products/repositories.",
     "main": "bin/index.js",
     "type": "module",
@@ -14,7 +14,7 @@
     },
     "exports": {
         ".": {
-            "import": "./bin/src/index.js"
+            "import": "./bin/index.js"
         },
         "./optimized/lint/*.js": {
             "import": "./bin/config/linter/*.js"


### PR DESCRIPTION
Correct the root `exports` entry to point at `./bin/index.js` instead of the invalid `./bin/src/index.js`, so package consumers resolve the main import correctly.

Before change, imports must be:
`import { eslintConfig } from '@shi-corp/development-utilities/optimized/lint/base.js'`

after change:
`import { baseLintConfig } from '@software-hardware-integration-lab/development-utilities'`

Change is backwards compatible so won't break consumers that auto upgrade to 3.0.1 but keep previous import syntax