### PR TITLE
Bump version to 3.0.1-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@software-hardware-integration-lab/development-utilities",
-    "version": "3.0.1",
+    "version": "3.0.1-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@software-hardware-integration-lab/development-utilities",
-            "version": "3.0.1",
+            "version": "3.0.1-beta",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "~10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@software-hardware-integration-lab/development-utilities",
-    "version": "3.0.1",
+    "version": "3.0.1-beta",
     "description": "Collection of configurations, settings and packages to be common across multiple products/repositories.",
     "main": "bin/index.js",
     "type": "module",


### PR DESCRIPTION
Updates the package version from 3.0.1 to 3.0.1-beta in package metadata, preparing a beta pre-release. The lockfile is updated to keep its root package version in sync.